### PR TITLE
support api v3

### DIFF
--- a/aiohere/aiohere.py
+++ b/aiohere/aiohere.py
@@ -19,8 +19,8 @@ from .exceptions import (
 )
 
 SCHEME = "https"
-API_HOST = "weather.cc.api.here.com"
-API_PATH = "/weather/1.0/report.json"
+API_HOST = "weather.hereapi.com"
+API_PATH = "/v3/report"
 API_URL = str(URL.build(scheme=SCHEME, host=API_HOST, path=API_PATH))
 
 
@@ -148,12 +148,11 @@ class AioHere:
 
         params: Mapping[str, str] = {
             "apiKey": self.api_key,
-            "product": str(product),
-            "oneobservation": "true" if one_observation is True else "false",
-            "metric": "true" if metric is True else "false",
-            "latitude": str(latitude),
-            "longitude": str(longitude),
-            "language": str(language),
+            "products": str(product),
+            "oneObservation": "true" if one_observation is True else "false",
+            "units": "metric" if metric is True else "imperial",
+            "location": f"{str(latitude)},{str(longitude)}",
+            "lang": str(language),
         }
         json_data = await self.request(params=params)
 


### PR DESCRIPTION
HERE has changed their API as new users signing up end up in their platform product.  The changes look to be fairly minimal, but I wasn't able to run tests locally to ensure that is still functioning.  As far as I can tell, the response is identical which simplifies this.

The `products` query param can take a comma joined list of products if desired, but left it as is to simplify migration.